### PR TITLE
ClockSpeedUpDxe: fix incorrect frequency output

### DIFF
--- a/Silicon/Qualcomm/QcomPkg/Drivers/ClockSpeedUpDxe/ClockSpeedUpDxe.c
+++ b/Silicon/Qualcomm/QcomPkg/Drivers/ClockSpeedUpDxe/ClockSpeedUpDxe.c
@@ -41,7 +41,7 @@ SetMaxFreq (
         ASSERT_EFI_ERROR (Status);
       }
 
-      DEBUG ((EFI_D_WARN, "CPU Cluster %d Now runs at %d Hz.\n", i, HzFreq));
+      DEBUG ((EFI_D_WARN, "CPU Cluster %d Now runs at %u Hz.\n", i, HzFreq));
     }
   } else {
     DEBUG ((EFI_D_WARN, "Max Freq is not Supported on this SoC.\n"));


### PR DESCRIPTION
### Checklist

[x] Is what you changed Tested?

For unsigned int (UINT32), %u must be used. Actually there are still many %d referring to unsigned int, but I did not touch these, they aren't going to get over signed int max value anyway.

Now the output is correct and not negative, tested on lisa.