### PR TITLE
Set USE_CUSTOM_DISPLAY_DRIVER to 1 in vayu.dsc for it to use DisplayDxe

### DIFF
--- a/Platforms/Xiaomi/vayuPkg/vayu.dsc
+++ b/Platforms/Xiaomi/vayuPkg/vayu.dsc
@@ -23,7 +23,7 @@
   BUILD_TARGETS                  = RELEASE|DEBUG
   SKUID_IDENTIFIER               = DEFAULT
   FLASH_DEFINITION               = vayuPkg/vayu.fdf
-  USE_CUSTOM_DISPLAY_DRIVER      = 0
+  USE_CUSTOM_DISPLAY_DRIVER      = 1
   HAS_BUILD_IN_KEYBOARD          = 0
 
   #


### PR DESCRIPTION
### What Changed

set USE_CUSTOM_DISPLAY_DRIVER to 1
### Reason

because if its 0 then it uses simplefbdxe which we dont want lol
### Checklist

* [x] Is what you changed Tested?
* [x] Is the Source Code Cleaned?
