### PR TITLE
tapas: Correct smbios info

### DIFF
--- a/Platforms/Xiaomi/tapasPkg/tapas.dsc
+++ b/Platforms/Xiaomi/tapasPkg/tapas.dsc
@@ -56,10 +56,10 @@
 
   # SmBios
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemVendor|"Xiaomi Inc"
-  gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemModel|"Redmi 12"
+  gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemModel|"Redmi Note 12 4G"
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemRetailModel|"tapas"
-  gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemRetailSku|"Redmi_12_tapas"
-  gSiliciumPkgTokenSpaceGuid.PcdSmbiosBoardModel|"Redmi 12"
+  gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemRetailSku|"Redmi_Note_12_4G_23021RAA"
+  gSiliciumPkgTokenSpaceGuid.PcdSmbiosBoardModel|"Redmi Note 12 4G"
 
   # Simple FrameBuffer
   gSiliciumPkgTokenSpaceGuid.PcdMipiFrameBufferWidth|1080


### PR DESCRIPTION
### What Changed

topas.dsc

### Reason

The maintainer wrote redmi 12 instead of redmi note 12 4g and there was no device model in sku

### Checklist

* [ ] Is what you changed Tested? No, because its more cosmetic change
* [x] Is the Source Code Cleaned?
