### PR TITLE
SM6225 devices: fix boot

### DIFF
--- a/Platforms/Xiaomi/fogPkg/fog.dsc
+++ b/Platforms/Xiaomi/fogPkg/fog.dsc
@@ -67,7 +67,7 @@
   gSiliciumPkgTokenSpaceGuid.PcdMipiFrameBufferColorDepth|32
 
   # Dynamic RAM Start Address
-  gQcomPkgTokenSpaceGuid.PcdRamPartitionBase|0x60000000
+  gQcomPkgTokenSpaceGuid.PcdRamPartitionBase|0x80000000
 
   # SD Card Slot
   gQcomPkgTokenSpaceGuid.PcdInitCardSlot|TRUE

--- a/Platforms/Xiaomi/spesPkg/spes.dsc
+++ b/Platforms/Xiaomi/spesPkg/spes.dsc
@@ -67,7 +67,7 @@
   gSiliciumPkgTokenSpaceGuid.PcdMipiFrameBufferColorDepth|32
 
   # Dynamic RAM Start Address
-  gQcomPkgTokenSpaceGuid.PcdRamPartitionBase|0x60000000
+  gQcomPkgTokenSpaceGuid.PcdRamPartitionBase|0x80000000
 
   # SD Card Slot
   gQcomPkgTokenSpaceGuid.PcdInitCardSlot|TRUE

--- a/Platforms/Xiaomi/tapasPkg/tapas.dsc
+++ b/Platforms/Xiaomi/tapasPkg/tapas.dsc
@@ -67,7 +67,7 @@
   gSiliciumPkgTokenSpaceGuid.PcdMipiFrameBufferColorDepth|32
 
   # Dynamic RAM Start Address
-  gQcomPkgTokenSpaceGuid.PcdRamPartitionBase|0x60000000
+  gQcomPkgTokenSpaceGuid.PcdRamPartitionBase|0x80000000
 
   # SD Card Slot
   gQcomPkgTokenSpaceGuid.PcdInitCardSlot|TRUE


### PR DESCRIPTION
### What Changed

Moved PcdRamPartitionBase from 0x60000000 to 0x80000000 for fog, spes & tapas

### Reason

DynamicRamDxe sent Access Denied and did not create RAM Partitions

### Checklist

<!-- Place a 'x' inside the '[}' to Check the Box. -->

* [X] Is what you changed Tested?
* [X] Is the Source Code Cleaned?
