### PR TITLE
surya: Update

### DIFF
--- a/Platforms/Xiaomi/suryaPkg/Include/APRIORI.inc
+++ b/Platforms/Xiaomi/suryaPkg/Include/APRIORI.inc
@@ -50,6 +50,7 @@ APRIORI DXE {
   INF Binaries/surya/QcomPkg/Drivers/TzDxe/TzDxeLA.inf
 
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+#  INF Binaries/surya/QcomPkg/Drivers/VariableDxe/VariableDxe.inf
 
   INF Binaries/surya/QcomPkg/Drivers/QcomWDogDxe/QcomWDogDxe.inf
   INF Binaries/surya/QcomPkg/Drivers/TLMMDxe/TLMMDxe.inf
@@ -61,6 +62,9 @@ APRIORI DXE {
 
   INF MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.inf
   INF MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
+  INF Binaries/surya/QcomPkg/Drivers/ASN1X509Dxe/ASN1X509Dxe.inf
+  INF Binaries/surya/QcomPkg/Drivers/SecRSADxe/SecRSADxe.inf
+  INF Binaries/surya/QcomPkg/Drivers/VerifiedBootDxe/VerifiedBootDxe.inf
   INF EmbeddedPkg/EmbeddedMonotonicCounter/EmbeddedMonotonicCounter.inf
   INF EmbeddedPkg/RealTimeClockRuntimeDxe/RealTimeClockRuntimeDxe.inf
   INF MdeModulePkg/Universal/PrintDxe/PrintDxe.inf
@@ -72,15 +76,16 @@ APRIORI DXE {
 
   INF MdeModulePkg/Universal/BdsDxe/BdsDxe.inf
 
-  INF Binaries/surya/QcomPkg/Drivers/VibratorDxe/VibratorDxe.inf
-  INF Binaries/surya/QcomPkg/Drivers/GpiDxe/GpiDxe.inf
   INF Binaries/surya/QcomPkg/Drivers/I2CDxe/I2CDxe.inf
-#  INF Binaries/surya/QcomPkg/Drivers/ASN1X509Dxe/ASN1X509Dxe.inf
   INF Binaries/surya/QcomPkg/Drivers/AdcDxe/AdcDxe.inf
   INF Binaries/surya/QcomPkg/Drivers/UsbPwrCtrlDxe/UsbPwrCtrlDxe.inf
   INF Binaries/surya/QcomPkg/Drivers/QcomChargerDxe/QcomChargerDxeLA.inf
   INF Binaries/surya/QcomPkg/Drivers/ChargerExDxe/ChargerExDxe.inf
   INF Binaries/surya/QcomPkg/Drivers/UsbfnDwc3Dxe/UsbfnDwc3Dxe.inf
+  INF Binaries/surya/QcomPkg/Drivers/UsbConfigDxe/UsbConfigDxe.inf
+
+  INF Binaries/surya/QcomPkg/Drivers/ButtonsDxe/ButtonsDxe.inf
+  INF Binaries/surya/QcomPkg/Drivers/TsensDxe/TsensDxe.inf
 
   INF Binaries/generic/QcomPkg/Drivers/XhciPciEmulationDxe/XhciPciEmulationDxe.inf
   INF Binaries/generic/QcomPkg/Drivers/XhciDxe/XhciDxe.inf
@@ -89,10 +94,6 @@ APRIORI DXE {
   INF MdeModulePkg/Bus/Usb/UsbKbDxe/UsbKbDxe.inf
   INF MdeModulePkg/Bus/Usb/UsbMassStorageDxe/UsbMassStorageDxe.inf
 
-  INF Binaries/surya/QcomPkg/Drivers/UsbConfigDxe/UsbConfigDxe.inf
-  INF Binaries/surya/QcomPkg/Drivers/ButtonsDxe/ButtonsDxe.inf
-  INF Binaries/surya/QcomPkg/Drivers/TsensDxe/TsensDxe.inf
-
 !if $(USE_CUSTOM_DISPLAY_DRIVER) == 1
   INF Binaries/surya/QcomPkg/Drivers/DisplayDxe/DisplayDxe.inf
 !else
@@ -100,6 +101,7 @@ APRIORI DXE {
 !endif
 
   INF Binaries/surya/QcomPkg/Drivers/LimitsDxe/LimitsDxe.inf
+  INF Binaries/surya/QcomPkg/Drivers/GpiDxe/GpiDxe.inf
   INF Binaries/surya/QcomPkg/Drivers/HashDxe/HashDxe.inf
   INF Binaries/surya/QcomPkg/Drivers/CipherDxe/CipherDxe.inf
   INF Binaries/surya/QcomPkg/Drivers/RNGDxe/RngDxe.inf

--- a/Platforms/Xiaomi/suryaPkg/Include/DXE.inc
+++ b/Platforms/Xiaomi/suryaPkg/Include/DXE.inc
@@ -3,6 +3,8 @@
   INF ArmPkg/Drivers/CpuDxe/CpuDxe.inf
   INF MdeModulePkg/Core/RuntimeDxe/RuntimeDxe.inf
   INF MdeModulePkg/Universal/SecurityStubDxe/SecurityStubDxe.inf
+  INF Binaries/surya/QcomPkg/Drivers/SecRSADxe/SecRSADxe.inf
+  INF Binaries/surya/QcomPkg/Drivers/VerifiedBootDxe/VerifiedBootDxe.inf
 
   INF Binaries/surya/QcomPkg/Drivers/TzDxe/ScmDxeLA.inf
   INF Binaries/surya/QcomPkg/Drivers/TzDxe/TzDxeLA.inf
@@ -12,6 +14,7 @@
   INF MdeModulePkg/Universal/ReportStatusCodeRouter/RuntimeDxe/ReportStatusCodeRouterRuntimeDxe.inf
   INF MdeModulePkg/Universal/StatusCodeHandler/RuntimeDxe/StatusCodeHandlerRuntimeDxe.inf
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
+#  INF Binaries/surya/QcomPkg/Drivers/VariableDxe/VariableDxe.inf
   INF EmbeddedPkg/EmbeddedMonotonicCounter/EmbeddedMonotonicCounter.inf
   INF EmbeddedPkg/SimpleTextInOutSerial/SimpleTextInOutSerial.inf
   INF MdeModulePkg/Universal/ResetSystemRuntimeDxe/ResetSystemRuntimeDxe.inf
@@ -63,8 +66,7 @@
   INF Binaries/surya/QcomPkg/Drivers/SdccDxe/SdccDxe.inf
   INF Binaries/surya/QcomPkg/Drivers/UFSDxe/UFSDxe.inf
   INF Binaries/surya/QcomPkg/Drivers/TLMMDxe/TLMMDxe.inf
-#  INF Binaries/surya/QcomPkg/Drivers/ASN1X509Dxe/ASN1X509Dxe.inf
-  INF Binaries/surya/QcomPkg/Drivers/VibratorDxe/VibratorDxe.inf
+  INF Binaries/surya/QcomPkg/Drivers/ASN1X509Dxe/ASN1X509Dxe.inf
 
 !if $(USE_CUSTOM_DISPLAY_DRIVER) == 1
   INF Binaries/surya/QcomPkg/Drivers/DisplayDxe/DisplayDxe.inf

--- a/Platforms/Xiaomi/suryaPkg/surya.dsc
+++ b/Platforms/Xiaomi/suryaPkg/surya.dsc
@@ -23,7 +23,7 @@
   BUILD_TARGETS                  = RELEASE|DEBUG
   SKUID_IDENTIFIER               = DEFAULT
   FLASH_DEFINITION               = suryaPkg/surya.fdf
-  USE_CUSTOM_DISPLAY_DRIVER      = 1
+  USE_CUSTOM_DISPLAY_DRIVER      = 0
   HAS_BUILD_IN_KEYBOARD          = 0
 
   #
@@ -68,7 +68,7 @@
   gSiliciumPkgTokenSpaceGuid.PcdMipiFrameBufferColorDepth|32
 
   # Platform Pei
-  gQcomPkgTokenSpaceGuid.PcdPlatformType|"LA"
+  gQcomPkgTokenSpaceGuid.PcdPlatformType|"WP"
 
   # Dynamic RAM Start Address
   gQcomPkgTokenSpaceGuid.PcdRamPartitionBase|0xA4500000


### PR DESCRIPTION
### What Changed
Dxe load order
WP instead of LA
SimpleFB instead of DisplayDxe

### Reason
Dxe load order is now more correct
Even though we have pep and use unpatched usb DXEs, usb host still requires WP to work under Windows for some reason
DisplayDxe still isn't perfect

### Checklist
* [X] Is what you changed Tested?
* [X] Is the Source Code Cleaned?
