### PR TITLE
Small fix

### DIFF
--- a/Platforms/Nothing/pongPkg/pong.fdf
+++ b/Platforms/Nothing/pongPkg/pong.fdf
@@ -95,7 +95,7 @@ READ_LOCK_STATUS   = TRUE
   # Device Tree
   #INF EmbeddedPkg/Drivers/DtPlatformDxe/DtPlatformDxe.inf
   #FILE FREEFORM = 25462CDA-221F-47DF-AC1D-259CFAA4E326 {
-  #  SECTION RAW = pongPkg/FdtBlob/sm8450-nothing-pong.dtb
+  #  SECTION RAW = pongPkg/FdtBlob/sm8475-nothing-pong.dtb
   #  SECTION UI = "DeviceTreeBlob"
   #}
 


### PR DESCRIPTION
### What Changed

<!-- Describe what you changed. (Write below this Commend) -->
Name of dtb in fdf
### Reason

<!-- The Reason why you did these Changes. (Write below this Commend) -->
Because according to 8450/75 mainline fork dtb has name sm8475-nothing-pong.dtb instead of sm8450-nothing-pong.dtb
### Checklist

<!-- Place a 'x' inside the '[}' to Check the Box. -->

* [x] Is what you changed Tested?
* [x] Is the Source Code Cleaned?
