### PR TITLE
Update: Linux status on alioth

### DIFF
--- a/Status.md
+++ b/Status.md
@@ -1189,7 +1189,7 @@
 | USB Power Delivery |                | ✅    |
 | Mass Storage       | Unknown Issues | ❌    |
 | Windows Boot       |                | ✅    |
-| Linux Boot         |                | ❌    |
+| Linux Boot         | Booted successfully,but TypeC and USB doesn't work.| ⚠️    |
 
 ### OS Status
 


### PR DESCRIPTION
### What Changed

<!-- Describe what you changed. (Write below this Commend) -->
Poco F3's Mu-Silicium UEFI support for Linux.

### Reason

<!-- The Reason why you did these Changes. (Write below this Commend) -->
After getting a Redmi K40 (Poco F3), I installed Mu-alioth version 2.8 and tried to boot a Standard AlpineLinux AARCH64 ISO. It turns out that GRUB and the Linux kernel are fully bootable. But the Linux kernel only seems to recognize UFS and will not power the Type-C interface. Therefore, USB keyboard, mouse, USB flash drive will not work under Linux at all. So I burned the AlpineLinux ISO to the "cust" partition and successfully entered the tty. Since the keyboard is not working, I can't control it, so I guess being able to enter the tty is the best result.

### Checklist

<!-- Place a 'x' inside the '[}' to Check the Box. -->

* [x] Is what you changed Tested?
* [x] Is the Source Code Cleaned?
![Image_1739191757546 1](https://github.com/user-attachments/assets/75bb2581-c603-4d8d-970b-7c4e8aacb9d9)

