### PR TITLE
Fix compilation errors r9qb2

### DIFF
--- a/Platforms/Samsung/r9qb2Pkg/PlatformBuild.py
+++ b/Platforms/Samsung/r9qb2Pkg/PlatformBuild.py
@@ -24,10 +24,10 @@ from edk2toollib.utility_functions import RunCmd
 #                                Common Configuration                                     #
 # ####################################################################################### #
 class CommonPlatform ():
-    PackagesSupported = ("r9qPkg")
+    PackagesSupported = ("r9qb2Pkg")
     ArchSupported = ("AARCH64")
     TargetsSupported = ("DEBUG", "RELEASE")
-    Scopes = ('r9q', 'gcc_aarch64_linux', 'edk2-build')
+    Scopes = ('r9qb2', 'gcc_aarch64_linux', 'edk2-build')
     WorkspaceRoot = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
     PackagesPath = (
         "Platforms/Samsung",
@@ -102,10 +102,10 @@ class SettingsManager (UpdateSettingsManager, SetupSettingsManager, PrEvalSettin
         return build_these_packages
 
     def GetPlatformDscAndConfig (self) -> tuple:
-        return ("r9qPkg/r9q.dsc", {})
+        return ("r9qb2Pkg/r9qb2.dsc", {})
 
     def GetName (self):
-        return "r9q"
+        return "r9qb2"
 
     def GetPackagesPath (self):
         return CommonPlatform.PackagesPath
@@ -139,7 +139,7 @@ class PlatformBuilder (UefiBuilder, BuildSettingsManager):
         return CommonPlatform.Scopes
 
     def GetName (self):
-        return "r9qPkg"
+        return "r9qb2Pkg"
 
     def GetLoggingLevel (self, loggerType):
         return logging.INFO
@@ -148,8 +148,8 @@ class PlatformBuilder (UefiBuilder, BuildSettingsManager):
     def SetPlatformEnv (self):
         logging.debug ("PlatformBuilder SetPlatformEnv")
 
-        self.env.SetValue ("PRODUCT_NAME", "r9q", "Platform Hardcoded")
-        self.env.SetValue ("ACTIVE_PLATFORM", "r9qPkg/r9q.dsc", "Platform Hardcoded")
+        self.env.SetValue ("PRODUCT_NAME", "r9qb2", "Platform Hardcoded")
+        self.env.SetValue ("ACTIVE_PLATFORM", "r9qb2Pkg/r9qb2.dsc", "Platform Hardcoded")
         self.env.SetValue ("TARGET_ARCH", "AARCH64", "Platform Hardcoded")
         self.env.SetValue ("TOOL_CHAIN_TAG", "CLANGPDB", "set default to clangpdb")
         self.env.SetValue ("EMPTY_DRIVE", "FALSE", "Default to false")

--- a/Resources/DTBs/r9qb2.dts
+++ b/Resources/DTBs/r9qb2.dts
@@ -1,7 +1,7 @@
 /dts-v1/;
 
 / {
-	model = "Samsung R9Q PROJECT (board-id,14)";
+	model = "Samsung r9qb2 PROJECT (board-id,14)";
 	compatible = "QCOM,LAHAINA-MTP", "QCOM,LAHAINA", "QCOM,MTP";
 	qcom,msm-id = <0x19f 0x20001 0x1c8 0x20001 0x1f5 0x20001>;
 	interrupt-parent = <0x01>;
@@ -18967,7 +18967,7 @@
 				tsp_io_ldo-supply = <0x2e4>;
 				tsp_avdd_ldo-supply = <0x2e6>;
 				sec,irq_gpio = <0x92 0x17 0x00>;
-				sec,project_name = "r9q", "";
+				sec,project_name = "r9qb2", "";
 				sec,firmware_name = "y792_o1.bin";
 				sec,bringup = <0x00>;
 				sec,regulator_boot_on;
@@ -18998,7 +18998,7 @@
 				tsp_io_ldo-supply = <0x5ff>;
 				tsp_avdd_ldo-supply = <0x2e6>;
 				sec,irq_gpio = <0x92 0x17 0x00>;
-				sec,project_name = "r9q", "";
+				sec,project_name = "r9qb2", "";
 				sec,bringup = <0x00>;
 				sec,ss_touch_num = <0x01>;
 				sec,tclm_level = <0x02>;

--- a/Resources/Scripts/r9qb2.sh
+++ b/Resources/Scripts/r9qb2.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # Build an Android kernel that is actually UEFI disguised as the Kernel
-cat ./BootShim/AARCH64/BootShim.bin "./Build/r9qPkg/${_TARGET_BUILD_MODE}_CLANGPDB/FV/R9Q_UEFI.fd" > "./Build/r9qPkg/${_TARGET_BUILD_MODE}_CLANGPDB/FV/R9Q_UEFI.fd-bootshim"||exit 1
-gzip -c < "./Build/r9qPkg/${_TARGET_BUILD_MODE}_CLANGPDB/FV/R9Q_UEFI.fd-bootshim" > "./Build/r9qPkg/${_TARGET_BUILD_MODE}_CLANGPDB/FV/R9Q_UEFI.fd-bootshim.gz"||exit 1
-cat "./Build/r9qPkg/${_TARGET_BUILD_MODE}_CLANGPDB/FV/R9Q_UEFI.fd-bootshim.gz" ./Resources/DTBs/r9q.dtb > ./Resources/bootpayload.bin||exit 1
+cat ./BootShim/AARCH64/BootShim.bin "./Build/r9qb2Pkg/${_TARGET_BUILD_MODE}_CLANGPDB/FV/R9QB2_UEFI.fd" > "./Build/r9qb2Pkg/${_TARGET_BUILD_MODE}_CLANGPDB/FV/R9QB2_UEFI.fd-bootshim"||exit 1
+gzip -c < "./Build/r9qb2Pkg/${_TARGET_BUILD_MODE}_CLANGPDB/FV/R9QB2_UEFI.fd-bootshim" > "./Build/r9qb2Pkg/${_TARGET_BUILD_MODE}_CLANGPDB/FV/R9QB2_UEFI.fd-bootshim.gz"||exit 1
+cat "./Build/r9qb2Pkg/${_TARGET_BUILD_MODE}_CLANGPDB/FV/R9QB2_UEFI.fd-bootshim.gz" ./Resources/DTBs/r9qb2.dtb > ./Resources/bootpayload.bin||exit 1
 
 # Create bootable Android boot.img
 python3 ./Resources/Scripts/mkbootimg.py \
@@ -19,5 +19,5 @@ python3 ./Resources/Scripts/mkbootimg.py \
   ||_error "\nFailed to create Android Boot Image!\n"
 
 # Compress Boot Image in a tar File for Odin/heimdall Flash
-tar -c boot.img -f Mu-r9q.tar||exit 1
-mv boot.img Mu-r9q.img||exit 1
+tar -c boot.img -f Mu-r9qb2.tar||exit 1
+mv boot.img Mu-r9qb2.img||exit 1


### PR DESCRIPTION
### Changes

When compiling r9qb2 it gave a path error, It's just now everything is renamed and it works

### Reason

because it didn't compile and to differentiate it from r9q

### Checklist

<!-- Replace the Space with an 'x' inside the '[ ]' to Check the Box. -->

* [x] Have the Changes been Tested?
* [x] Has the Source Code been Cleaned Up?
