### PR TITLE
Add S2MPS_19_22 Driver for E9830 Devices, Also add power off support for E9830 devices

### DIFF
--- a/Platforms/Samsung/x1sPkg/Include/APRIORI.inc
+++ b/Platforms/Samsung/x1sPkg/Include/APRIORI.inc
@@ -21,6 +21,8 @@ APRIORI DXE {
   INF SamsungPkg/Drivers/GpioDxe/GpioDxe.inf
   INF SamsungPkg/Drivers/SpeedyDxe/SpeedyDxe.inf
 
+  INF E9830Pkg/Drivers/S2MPS_19_22Dxe/S2MPS_19_22Dxe.inf
+
   INF MdeModulePkg/Universal/Variable/RuntimeDxe/VariableRuntimeDxe.inf
   INF MdeModulePkg/Universal/ResetSystemRuntimeDxe/ResetSystemRuntimeDxe.inf
   INF MdeModulePkg/Universal/WatchdogTimerDxe/WatchdogTimer.inf

--- a/Platforms/Samsung/x1sPkg/Include/DXE.inc
+++ b/Platforms/Samsung/x1sPkg/Include/DXE.inc
@@ -28,6 +28,8 @@
   INF SamsungPkg/Drivers/GpioDxe/GpioDxe.inf
   INF SamsungPkg/Drivers/SpeedyDxe/SpeedyDxe.inf
 
+  INF E9830Pkg/Drivers/S2MPS_19_22Dxe/S2MPS_19_22Dxe.inf
+
 !if $(USE_CUSTOM_DISPLAY_DRIVER) == 0
   INF SiliciumPkg/Drivers/SimpleFbDxe/SimpleFbDxe.inf
 !endif

--- a/Silicon/Samsung/E9830Pkg/Drivers/S2MPS_19_22Dxe/S2MPS_19_22Dxe.c
+++ b/Silicon/Samsung/E9830Pkg/Drivers/S2MPS_19_22Dxe/S2MPS_19_22Dxe.c
@@ -1,0 +1,157 @@
+/**
+  Copyright@ Samsung Electronics Co. LTD
+
+  This software is proprietary of Samsung Electronics.
+  No part of this software, either material or conceptual may be copied or distributed, transmitted,
+  transcribed, stored in a retrieval system or translated into any human or computer language in any form by any means,
+  electronic, mechanical, manual or otherwise, or disclosed
+  to third parties without the express written permission of Samsung Electronics.
+**/
+
+#include <Library/DebugLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/MemoryMapHelperLib.h>
+
+#include <Protocol/EfiSpeedy.h>
+#include <Protocol/EfiPMIC.h>
+
+#include "S2MPS_19_22_Registers.h"
+
+ARM_MEMORY_REGION_DESCRIPTOR_EX Speedy1Region;
+ARM_MEMORY_REGION_DESCRIPTOR_EX Speedy2Region;
+
+// Cached copy of the Speedy protocol instance
+EFI_SPEEDY_PROTOCOL *gSpeedy = NULL;
+
+VOID PMICInit ()
+{
+  UINT8 Register;
+
+  /* Disable Manual Reset */
+  gSpeedy->Read(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_CTRL1, &Register);
+  Register &= ~MRSTB_EN;
+  gSpeedy->Write(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_CTRL1, Register);
+
+  /* Enable Warm Reset */
+  gSpeedy->Read(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_CTRL3, &Register);
+  Register |= WRSTEN;
+  gSpeedy->Write(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_CTRL3, Register);
+
+  /* LCD power */
+  gSpeedy->Read(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO3M_CTRL, &Register);
+  Register |= S2MPS_OUTPUT_ON_NORMAL;
+  gSpeedy->Write(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO3M_CTRL, Register);
+
+  gSpeedy->Read(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO4M_CTRL, &Register);
+  Register |= S2MPS_OUTPUT_ON_NORMAL;
+  gSpeedy->Write(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO4M_CTRL, Register);
+
+  gSpeedy->Read(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO9M_CTRL, &Register);
+  Register |= S2MPS_OUTPUT_ON_NORMAL;
+  gSpeedy->Write(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO9M_CTRL, Register);
+
+  gSpeedy->Read(Speedy2Region.Address, S2MPS22_PM_ADDR, S2MPS22_PM_LDO4S_CTRL, &Register);
+  Register |= S2MPS_OUTPUT_ON_NORMAL;
+  gSpeedy->Write(Speedy2Region.Address, S2MPS22_PM_ADDR, S2MPS22_PM_LDO4S_CTRL, Register);
+
+  /* ICEN enable for PB02 & PB03 */
+  gSpeedy->Read(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO16M_CTRL, &Register);
+  Register |= S2MPS_OUTPUT_ON_NORMAL;
+  gSpeedy->Write(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO16M_CTRL, Register);
+
+  /* LDO 10, 11, 12 On for USB */
+  gSpeedy->Read(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO10M_CTRL, &Register);
+  Register |= S2MPS_OUTPUT_ON_TCXO;
+  gSpeedy->Write(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO10M_CTRL, Register);
+
+  gSpeedy->Read(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO11M_CTRL, &Register);
+  Register |= S2MPS_OUTPUT_ON_TCXO;
+  gSpeedy->Write(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO11M_CTRL, Register);
+
+  gSpeedy->Read(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO12M_CTRL, &Register);
+  Register |= S2MPS_OUTPUT_ON_TCXO;
+  gSpeedy->Write(Speedy1Region.Address, S2MPS19_PM_ADDR, S2MPS19_PM_LDO12M_CTRL, Register);
+
+  /* Enable WTSR */
+  gSpeedy->Read(Speedy1Region.Address, S2MPS19_RTC_ADDR, S2MPS19_RTC_WTSR_SMPL, &Register);
+  Register = (Register & 0xB8) | 0x43;
+  gSpeedy->Write(Speedy1Region.Address, S2MPS19_RTC_ADDR, S2MPS19_RTC_WTSR_SMPL, Register);
+}
+
+VOID PMICDisableWTSR ()
+{
+  UINT8 Register;
+
+  gSpeedy->Read(Speedy1Region.Address, S2MPS19_RTC_ADDR, S2MPS19_RTC_WTSR_SMPL, &Register);
+
+  Register &= ~(1 << 6); // Clear bit 6 (WTSR)
+
+  gSpeedy->Write(Speedy1Region.Address, S2MPS19_RTC_ADDR, S2MPS19_RTC_WTSR_SMPL, Register);
+}
+
+VOID PMICDisableSMPL ()
+{
+  UINT8 Register;
+
+  gSpeedy->Read(Speedy1Region.Address, S2MPS19_RTC_ADDR, S2MPS19_RTC_WTSR_SMPL, &Register);
+
+  Register &= ~(1 << 7); // Clear bit 7 (SMPL)
+  Register &= ~(1 << 8); // Clear bit 8 (SUB_SMPL)
+
+  gSpeedy->Write(Speedy1Region.Address, S2MPS19_RTC_ADDR, S2MPS19_RTC_WTSR_SMPL, Register);
+}
+
+VOID PMICShutdown()
+{
+  UINT8 Register = 0x80;
+
+  gSpeedy->Write(Speedy2Region.Address, S2MPS22_PM_ADDR, S2MPS22_PM_CTRL1, Register);
+}
+
+EFI_PMIC_PROTOCOL mPMIC = {
+  PMICDisableWTSR,
+  PMICDisableSMPL,
+  PMICShutdown
+};
+
+EFI_STATUS
+EFIAPI
+InitS2MPS_19_22Driver (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE *SystemTable)
+{
+  EFI_STATUS Status;
+
+  // Locate Speedy Memory Regions. ASSERT if not found.
+  Status = LocateMemoryMapAreaByName ("Speedy-1", &Speedy1Region);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((EFI_D_ERROR, "Failed to Locate 'Speedy-1' Memory Region! Status = %r\n", Status));
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  Status = LocateMemoryMapAreaByName ("Speedy-2", &Speedy2Region);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((EFI_D_ERROR, "Failed to Locate 'Speedy-2' Memory Region! Status = %r\n", Status));
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  // Find the Speedy protocol. ASSERT if not found.
+  Status = gBS->LocateProtocol (&gEfiSpeedyProtocolGuid, NULL, (VOID **)&gSpeedy);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((EFI_D_ERROR, "Failed to Locate Speedy Protocol!\n"));
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  PMICInit ();
+
+  // Register PMIC Protocol
+  Status = gBS->InstallMultipleProtocolInterfaces (&ImageHandle, &gEfiPMICProtocolGuid, &mPMIC, NULL);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((EFI_D_ERROR, "Failed to Register PMIC Protocol!\n"));
+    ASSERT_EFI_ERROR (Status);
+  }
+
+  DEBUG((EFI_D_WARN, "S2MPS_19_22 PMIC Initialised!\n"));
+
+  return EFI_SUCCESS;
+}

--- a/Silicon/Samsung/E9830Pkg/Drivers/S2MPS_19_22Dxe/S2MPS_19_22Dxe.inf
+++ b/Silicon/Samsung/E9830Pkg/Drivers/S2MPS_19_22Dxe/S2MPS_19_22Dxe.inf
@@ -1,0 +1,30 @@
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = S2MPS_19_22Dxe
+  FILE_GUID                      = 07431110-22AC-42A9-B8FD-CFE2A81B2AA9
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = InitS2MPS_19_22Driver
+
+[Sources]
+  S2MPS_19_22Dxe.c
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  MdePkg/MdePkg.dec
+  SiliciumPkg/SiliciumPkg.dec
+  SamsungPkg/SamsungPkg.dec
+  E9830Pkg/E9830Pkg.dec
+
+[LibraryClasses]
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+  MemoryMapHelperLib
+  DebugLib
+
+[Protocols]
+  gEfiSpeedyProtocolGuid
+  gEfiPMICProtocolGuid
+
+[Depex]
+  TRUE

--- a/Silicon/Samsung/E9830Pkg/Drivers/S2MPS_19_22Dxe/S2MPS_19_22_Registers.h
+++ b/Silicon/Samsung/E9830Pkg/Drivers/S2MPS_19_22Dxe/S2MPS_19_22_Registers.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright@ Samsung Electronics Co. LTD
+ *
+ * This software is proprietary of Samsung Electronics.
+ * No part of this software, either material or conceptual may be copied or distributed, transmitted,
+ * transcribed, stored in a retrieval system or translated into any human or computer language in any form by any means,
+ * electronic, mechanical, manual or otherwise, or disclosed
+ * to third parties without the express written permission of Samsung Electronics.
+ */
+
+#ifndef _S2MPS_19_22_REGISTERS_H_
+#define _S2MPS_19_22_REGISTERS_H_
+
+/* S2MPS19 slave address */
+#define S2MPS19_PM_ADDR		0x1
+#define S2MPS19_RTC_ADDR	0x2
+
+/* S2MPS22 slave address */
+#define S2MPS22_PM_ADDR		0x1
+
+/* S2MPS19 Register Address */
+#define S2MPS19_PM_INT1		0x000
+#define S2MPS19_PM_INT2		0x001
+#define S2MPS19_PM_INT3		0x002
+#define S2MPS19_PM_INT4		0x003
+#define S2MPS19_PM_INT5		0x004
+#define S2MPS19_PM_PWRONSRC	0x010
+#define S2MPS19_PM_OFFSRC	0x011
+#define S2MPS19_PM_RTC_BUF	0x013
+#define S2MPS19_PM_CTRL1	0x014
+#define S2MPS19_PM_CTRL3	0x016
+#define S2MPS19_PM_ETC_OTP	0x018
+#define S2MPS19_PM_RTC_BUF	0x013
+
+#define S2MPS19_PM_LDO2M_CTRL	0x047
+#define S2MPS19_PM_LDO3M_CTRL	0x048
+#define S2MPS19_PM_LDO4M_CTRL	0x049
+#define S2MPS19_PM_LDO9M_CTRL	0x04E
+#define S2MPS19_PM_LDO15M_CTRL	0x054
+#define S2MPS19_PM_LDO10M_CTRL	0x04F
+#define S2MPS19_PM_LDO11M_CTRL	0x050
+#define S2MPS19_PM_LDO12M_CTRL	0x051
+#define S2MPS19_PM_LDO16M_CTRL	0x055
+#define S2MPS19_PM_LDO17M_CTRL	0x056
+
+#define S2MPS19_RTC_WTSR_SMPL	0x001
+#define S2MPU19_RTC_CAP_SEL	0x003
+
+/* S2MPS22 Register Address */
+#define S2MPS22_PM_CTRL1	0x013
+#define S2MPS22_PM_LDO4S_CTRL	0x02D
+
+/*
+ * CTRL1
+ */
+#define MRSTB_EN		(0x1 << 4)
+
+/*
+ * CTRL3
+ */
+#define WRSTBIEN		(0x1 << 6)
+#define MRSEL		(0x1 << 5)
+#define WRSTEN			(0x1 << 4)
+
+/*
+ * LDOx_CTRL
+ */
+#define S2MPS_OUTPUT_ON_NORMAL	(0x3 << 6)
+#define S2MPS_OUTPUT_ON_TCXO	(0x1 << 6)
+
+
+#define S2MPS19_RTC_WTSR_SMPL	0x001
+#define S2MPS19_RTC_UPDATE	0x002
+#define S2MPS19_RTC_CAP_SEL	0x003
+#define S2MPS19_RTC_MSEC	0x004
+#define S2MPS19_RTC_SEC		0x005
+#define S2MPS19_RTC_MIN		0x006
+#define S2MPS19_RTC_HOUR	0x007
+#define S2MPS19_RTC_WEEK	0x008
+#define S2MPS19_RTC_DAY		0x009
+#define S2MPS19_RTC_MON		0x00A
+#define S2MPS19_RTC_YEAR	0x00B
+
+/* RTC Counter Register offsets */
+enum {
+  PMIC_RTC_SEC = 0,
+  PMIC_RTC_MIN,
+  PMIC_RTC_HOUR,
+  PMIC_RTC_WEEK,
+  PMIC_RTC_DATE,
+  PMIC_RTC_MONTH,
+  PMIC_RTC_YEAR,
+  NR_PMIC_RTC_CNT_REGS,
+};
+
+/*
+ * RTC_BUF
+ */
+#define _32KHZAP_EN	(0x1 << 0)
+#define _32KHZPERI_EN	(0x1 << 2)
+
+#endif  /* _S2MPS_19_22_REGISTERS_H_ */

--- a/Silicon/Samsung/E9830Pkg/Drivers/S2MPS_19_22Dxe/Source.txt
+++ b/Silicon/Samsung/E9830Pkg/Drivers/S2MPS_19_22Dxe/Source.txt
@@ -1,0 +1,3 @@
+REPO:   https://github.com/exynos990-mainline/lk3rd/
+BRANCH: dev
+FILE:   dev/power/pmic/s2mps_19_22/pmic_s2mps_19_22.c

--- a/Silicon/Samsung/E9830Pkg/E9830Pkg.dec
+++ b/Silicon/Samsung/E9830Pkg/E9830Pkg.dec
@@ -1,0 +1,14 @@
+[Defines]
+  DEC_SPECIFICATION                   = 0x00010005
+  PACKAGE_NAME                        = E9830Pkg
+  PACKAGE_GUID                        = D86C0D82-8FFB-449D-8F68-0A9811445755
+  PACKAGE_VERSION                     = 0.1
+
+[Includes]
+  Include                             # Root include for the package
+
+[Guids]
+  gE9830PkgTokenSpaceGuid             = { 0x6CBF6D5E, 0xA40D, 0x4F98, { 0x91, 0x15, 0xAC, 0xC7, 0xEC, 0xE3, 0xCD, 0xF6 } }
+
+[Protocols]
+  gEfiPMICProtocolGuid                   = { 0x09723148, 0xBA1F, 0x4751, { 0x8F, 0x0D, 0x5B, 0xC6, 0xA0, 0xCC, 0xA2, 0x7A } }

--- a/Silicon/Samsung/E9830Pkg/E9830Pkg.dsc.inc
+++ b/Silicon/Samsung/E9830Pkg/E9830Pkg.dsc.inc
@@ -72,4 +72,7 @@
   ResetSystemLib|E9830Pkg/Library/ResetSystemLib/ResetSystemLib.inf
   SoCPlatformLib|E9830Pkg/Library/SoCPlatformLib/SoCPlatformLib.inf
 
+[Components]
+  E9830Pkg/Drivers/S2MPS_19_22Dxe/S2MPS_19_22Dxe.inf
+
 !include SamsungPkg/SamsungPkg.dsc.inc

--- a/Silicon/Samsung/E9830Pkg/Include/Protocol/EfiPMIC.h
+++ b/Silicon/Samsung/E9830Pkg/Include/Protocol/EfiPMIC.h
@@ -1,0 +1,40 @@
+#ifndef _EFI_PMIC_H_
+#define _EFI_PMIC_H_
+
+//
+// Global GUID for the PMIC Protocol
+//
+#define EFI_PMIC_PROTOCOL_GUID { 0x09723148, 0xBA1F, 0x4751, { 0x8F, 0x0D, 0x5B, 0xC6, 0xA0, 0xCC, 0xA2, 0x7A } }
+
+//
+// Declare forward Reference to the PMIC Protocol
+//
+typedef struct _EFI_PMIC_PROTOCOL EFI_PMIC_PROTOCOL;
+
+/**
+  This Function disables WTSR on the PMIC.
+**/
+typedef
+VOID (EFIAPI *EFI_DISABLE_WTSR) ();
+
+/**
+  This Function disables SMPL on the PMIC.
+**/
+typedef
+VOID (EFIAPI *EFI_DISABLE_SMPL) ();
+
+/**
+  This Function shuts the PMIC down.
+**/
+typedef
+VOID (EFIAPI *EFI_SHUTDOWN_PMIC) ();
+
+struct _EFI_PMIC_PROTOCOL {
+  EFI_DISABLE_WTSR   DisableWTSR;
+  EFI_DISABLE_SMPL   DisableSMPL;
+  EFI_SHUTDOWN_PMIC  ShutdownPMIC;
+};
+
+extern EFI_GUID gEfiPMICProtocolGuid;
+
+#endif /* _EFI_PMIC_H_ */

--- a/Silicon/Samsung/E9830Pkg/Library/ResetSystemLib/ResetSystemLib.inf
+++ b/Silicon/Samsung/E9830Pkg/Library/ResetSystemLib/ResetSystemLib.inf
@@ -13,8 +13,17 @@
   ArmPkg/ArmPkg.dec
   MdeModulePkg/MdeModulePkg.dec
   MdePkg/MdePkg.dec
+  SamsungPkg/SamsungPkg.dec
+  E9830Pkg/E9830Pkg.dec
 
 [LibraryClasses]
+  UefiBootServicesTableLib
   BaseLib
   DebugLib
   IoLib
+  TimerLib
+
+[Protocols]
+  gEfiGpioProtocolGuid
+  gEfiPMICProtocolGuid
+

--- a/Silicon/Samsung/E9830Pkg/Library/ResetSystemLib/SamsungPMURegisters.h
+++ b/Silicon/Samsung/E9830Pkg/Library/ResetSystemLib/SamsungPMURegisters.h
@@ -2,6 +2,7 @@
 #define __SAMSUNGPMUREGISTERS_H_
 
 #define EXYNOS_PMU_BASE             0x15860000
+#define PS_HOLD			    0x030C
 #define SWRESET		            0x3A00
 #define RST_STAT	            0x0404
 #define SWRESET_TRIGGER	            (1 << 1)


### PR DESCRIPTION
### Changes

Add S2MPS_19_22 Driver for E9830 Devices, Also add power off support for E9830 devices

### Reason

More functionality the better

### Checklist

* [x] Have the Changes been Tested?
* [x] Has the Source Code been Cleaned Up?
