### PR TITLE
APRIORI.inc: fix misspelling of 'USE_CUSTOM_DISPLAY_DRIVER'

### DIFF
--- a/Platforms/Realme/balePkg/Include/APRIORI.inc
+++ b/Platforms/Realme/balePkg/Include/APRIORI.inc
@@ -115,7 +115,7 @@ APRIORI DXE {
 !endif
 
   INF Binaries/bale/QcomPkg/Drivers/LimitsDxe/LimitsDxe.inf
-!if $(USE_CUSTOM_DRIVER) == 1
+!if $(USE_CUSTOM_DISPLAY_DRIVER) == 1
   INF Binaries/bale/QcomPkg/Drivers/CPRDxe/CPRDxe.inf
 !endif
   INF Binaries/bale/QcomPkg/Drivers/GpiDxe/GpiDxe.inf


### PR DESCRIPTION
### Changes

changed line in APRIORI.inc, which was responsible for if statement, relatable for custom display driver

### Reason

thats probably was the reason of patches not working on my DisplayDxe driver

### Checklist

<!-- Replace the Space with an 'x' inside the '[ ]' to Check the Box. -->

* [x] Have the Changes been Tested?
* [x] Has the Source Code been Cleaned Up?
