### PR TITLE
nuwa: Use Header Version 1 instead of 4

### DIFF
--- a/Resources/Scripts/nuwa.sh
+++ b/Resources/Scripts/nuwa.sh
@@ -11,6 +11,6 @@ python3 ./Resources/Scripts/mkbootimg.py \
   --ramdisk ./Resources/ramdisk \
   --os_version 15.0.0 \
   --os_patch_level "$(date '+%Y-%m')" \
-  --header_version 4 \
+  --header_version 1 \
   -o Mu-nuwa.img \
   ||_error "\nFailed to create Android Boot Image!\n"


### PR DESCRIPTION
With header 4, only fastboot boot would work and not flashing

### Changes

Changed nuwa Script to use header version 1 instead of version 4

### Reason

Booting normally with fastboot flash was broken with header 4

### Checklist

* [x] Have the Changes been Tested?
* [x] Has the Source Code been Cleaned Up?
