### PR TITLE
Use binary package of yay instead of source package

### DIFF
--- a/setup_env.sh
+++ b/setup_env.sh
@@ -47,7 +47,7 @@ elif [ ${PAK} = dnf ]; then
     sudo dnf install -y git mono-devel nuget nasm make lld gcc automake gcc-aarch64-linux-gnu python3 python3-pip gettext gnupg ca-certificates git git-core clang llvm curl lld||_error "\nFailed to install Packages!\n"
 elif [ ${PAK} = pacman ] || [ ${PAK} = yay ]; then
     if [ ${PAK} = pacman ]; then
-        sudo pacman -Syu --needed git base-devel && git clone https://aur.archlinux.org/yay.git && cd yay && makepkg -si
+        sudo pacman -Syu --needed git base-devel && git clone https://aur.archlinux.org/yay-bin.git && cd yay && makepkg -si
     fi
     yay -Sy git mono base-devel nuget uuid lld nasm aarch64-linux-gnu-gcc python3 python python-distutils-extra python-pip gettext gnupg ca-certificates python-virtualenv python-pipenv clang llvm curl lld||_error "\nFailed to install Packages!\n"
 else


### PR DESCRIPTION
This PR replaces yay with yay-bin which is binary AUR package released by same package author.  It'll make installation of yay faster and we also don't have to install unnecessary build dependencies.