### PR TITLE
Partially fix SMBIOS

### DIFF
--- a/Platforms/Nothing/pongPkg/pong.dsc
+++ b/Platforms/Nothing/pongPkg/pong.dsc
@@ -48,8 +48,8 @@
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemManufacturer|"Nothing"
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemModel|"Phone 2"
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemRetailModel|"pong"
-  gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemRetailSku|"Phone_2_pong"
-  gSiliciumPkgTokenSpaceGuid.PcdSmbiosBoardModel|"Phone 2"
+  gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemRetailSku|"A065"
+  gSiliciumPkgTokenSpaceGuid.PcdSmbiosBoardModel|"Phone 2" # Unknown
 
   # Simple Frame Buffer
   gSiliciumPkgTokenSpaceGuid.PcdPrimaryFrameBufferWidth|1080

--- a/Platforms/Nothing/spacewarPkg/spacewar.dsc
+++ b/Platforms/Nothing/spacewarPkg/spacewar.dsc
@@ -48,8 +48,8 @@
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemManufacturer|"Nothing"
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemModel|"Phone 1"
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemRetailModel|"spacewar"
-  gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemRetailSku|"Phone_1_spacewar"
-  gSiliciumPkgTokenSpaceGuid.PcdSmbiosBoardModel|"Phone 1"
+  gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemRetailSku|"A063"
+  gSiliciumPkgTokenSpaceGuid.PcdSmbiosBoardModel|"Phone 1" # Unknown
 
   # Simple Frame Buffer
   gSiliciumPkgTokenSpaceGuid.PcdPrimaryFrameBufferWidth|1080

--- a/Platforms/OnePlus/dodgePkg/dodge.dsc
+++ b/Platforms/OnePlus/dodgePkg/dodge.dsc
@@ -48,7 +48,7 @@
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemManufacturer|"OnePlus"
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemModel|"13"
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemRetailModel|"dodge"
-  gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemRetailSku|"CPH2649"
+  gSiliciumPkgTokenSpaceGuid.PcdSmbiosSystemRetailSku|"CPH2653"
   gSiliciumPkgTokenSpaceGuid.PcdSmbiosBoardModel|"23893"
 
   # Simple Frame Buffer


### PR DESCRIPTION
### Changes

<!-- Describe what you Changed. (Write below this Comment) -->
pong&spacewar: replace incorrect values to A0XX ( BoardModel unknown, assume taro for pong?)
dodge: correct RetailSku to global/EEA variant ( as it was ported on EEA variant )
### Reason

<!-- Explain why you made these Changes. (Write below this Comment) -->
because others do it
### Checklist

<!-- Replace the Space with an 'x' inside the '[ ]' to Check the Box. -->

* [x] Have the Changes been Tested?
* [x] Has the Source Code been Cleaned Up?
