### PR TITLE
Status: Update USB Host and Power Delivery status for nuwa (Linux)

### DIFF
--- a/Status.md
+++ b/Status.md
@@ -1053,9 +1053,9 @@
 | NFC Sensor           |                         | ❌    |
 | Temperature Sensor   |                         | ❌    |
 | Battery              |                         | ✅    |
-| USB Host Mode        | Untested. Should work   | ❔    |
+| USB Host Mode        |                         | ✅    |
 | USB Device Mode      |                         | ✅    |
-| USB Power Delivery   | Untested                | ❔    |
+| USB Power Delivery   |                         | ✅    |
 | Charging             |                         | ✅    |
 | WLAN                 |                         | ✅    |
 | CPU                  |                         | ✅    |


### PR DESCRIPTION
### Changes

Changed the status for nuwa of USB Host Mode and Power Delivery to working (✅) instead of unknown

### Reason

I tested the functionnality on my device, it's been a while since I haven't booted Linux on it and I did now so I thought why not test this.

### Checklist

* [x] Have the Changes been Tested?
* [x] Has the Source Code been Cleaned Up?
