### PR TITLE
add shebang to build_uefi.py

### DIFF
--- a/build_uefi.py
+++ b/build_uefi.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 from pathlib import Path
 from dataclasses import dataclass
 


### PR DESCRIPTION
### Changes

<!-- Describe what you Changed. (Write below this Comment) -->

added shebang to python build script

### Reason

<!-- Explain why you made these Changes. (Write below this Comment) -->

this lets you run it on linux by doing just `./build_uefi.py` instead of `python build_uefi.py`. don't worry, it doesn't break windows

### Checklist

<!-- Replace the Space with an 'x' inside the '[ ]' to Check the Box. -->

* [x] Have the Changes been Tested?
* [x] Has the Source Code been Cleaned Up?
