### PR TITLE
Remove remaining MMU terminators

### DIFF
--- a/Platforms/OnePlus/dodgePkg/Library/MemoryMapLib/MemoryMapLib.c
+++ b/Platforms/OnePlus/dodgePkg/Library/MemoryMapLib/MemoryMapLib.c
@@ -48,10 +48,7 @@ gMemoryDescriptor[] = {
   {"AOSS",               0x0B000000, 0x04000000, AddDev, MMAP_IO, UNCACHEABLE, MmIO, NS_DEVICE},
   {"TLMM",               0x0F000000, 0x01000000, AddDev, MMAP_IO, UNCACHEABLE, MmIO, NS_DEVICE},
   {"SMMU",               0x15000000, 0x00200000, AddDev, MMAP_IO, UNCACHEABLE, MmIO, NS_DEVICE},
-  {"APSS_HM",            0x16000000, 0x06000000, AddDev, MMAP_IO, UNCACHEABLE, MmIO, NS_DEVICE},
-  
-  // Terminator for MMU
-  {"Terminator", 0, 0, 0, 0, 0, 0, 0}
+  {"APSS_HM",            0x16000000, 0x06000000, AddDev, MMAP_IO, UNCACHEABLE, MmIO, NS_DEVICE}
 };
 
 VOID

--- a/Platforms/Realme/bitraPkg/Library/MemoryMapLib/MemoryMapLib.c
+++ b/Platforms/Realme/bitraPkg/Library/MemoryMapLib/MemoryMapLib.c
@@ -50,10 +50,7 @@ gMemoryDescriptor[] = {
   {"TLMM_SOUTH",        0x0F500000, 0x00300000, AddDev, MMAP_IO, UNCACHEABLE, MmIO,   NS_DEVICE},
   {"TLMM_NORTH",        0x0F900000, 0x00300000, AddDev, MMAP_IO, UNCACHEABLE, MmIO,   NS_DEVICE},
   {"SMMU",              0x15000000, 0x000D0000, AddDev, MMAP_IO, UNCACHEABLE, MmIO,   NS_DEVICE},
-  {"APSS_HM",           0x17800000, 0x0d981000, AddDev, MMAP_IO, UNCACHEABLE, MmIO,   NS_DEVICE},
-  
-  // Terminator for MMU
-  {"Terminator", 0, 0, 0, 0, 0, 0, 0}
+  {"APSS_HM",           0x17800000, 0x0d981000, AddDev, MMAP_IO, UNCACHEABLE, MmIO,   NS_DEVICE}
 };
 
 VOID

--- a/Platforms/Xiaomi/equuleusPkg/Library/ConfigurationMapLib/ConfigurationMapLib.c
+++ b/Platforms/Xiaomi/equuleusPkg/Library/ConfigurationMapLib/ConfigurationMapLib.c
@@ -26,10 +26,7 @@ gConfigurationDescriptor[] = {
   {"TzAppsRegnSize", 0x03C00000},
   {"ImageFVFlashed", 0x0},
   {"EnableLogFsSyncInRetail", 0x1},
-  {"EnableSecurityHoleForSplashPartition", 0x1},
- 
-  // Terminator
-  {"Terminator", 0xFFFFFFFF}
+  {"EnableSecurityHoleForSplashPartition", 0x1}
 };
 
 VOID

--- a/Platforms/ZTE/nx729jPkg/Library/ConfigurationMapLib/ConfigurationMapLib.c
+++ b/Platforms/ZTE/nx729jPkg/Library/ConfigurationMapLib/ConfigurationMapLib.c
@@ -45,10 +45,7 @@ gConfigurationDescriptor[] = {
   {"UfsSmmuConfigForOtherBootDev", 1},
   {"UsbFnIoRevNum", 0x00010001},
   {"UefiMemUseThreshold", 0xE1},
-  {"USBHS1_Config", 0x0},
-
-  // Terminator 
-  {"Terminator", 0xFFFFFFFF}
+  {"USBHS1_Config", 0x0}
 };
 
 VOID


### PR DESCRIPTION
### Changes

<!-- Describe what you Changed. (Write below this Comment) -->

Remove remaining Terminator regions in some devices maps

### Reason

<!-- Explain why you made these Changes. (Write below this Comment) -->

After the refactor they're not needed anymore, but some devices still have them, making them get stuck on "MMU In"

### Checklist

<!-- Replace the Space with an 'x' inside the '[ ]' to Check the Box. -->

* [x] Have the Changes been Tested?
* [x] Has the Source Code been Cleaned Up?
