### PR TITLE
dodge: Remove useless oplus Dxes

### DIFF
--- a/Platforms/OnePlus/dodgePkg/Include/DXE.inc
+++ b/Platforms/OnePlus/dodgePkg/Include/DXE.inc
@@ -24,7 +24,7 @@
   INF MdeModulePkg/Universal/HiiDatabaseDxe/HiiDatabaseDxe.inf
 
   INF Binaries/dodge/QcomPkg/Drivers/FontDxe/FontDxe.inf
-  #INF Binaries/dodge/QcomPkg/Drivers/QcomWDogDxe/QcomWDogDxe.inf 
+  INF Binaries/dodge/QcomPkg/Drivers/QcomWDogDxe/QcomWDogDxe.inf 
 
   INF ArmPkg/Drivers/ArmGicDxe/ArmGicDxe.inf
   INF ArmPkg/Drivers/TimerDxe/TimerDxe.inf
@@ -47,7 +47,6 @@
   INF MdeModulePkg/Universal/Disk/UnicodeCollation/EnglishDxe/EnglishDxe.inf
 
   INF Binaries/dodge/QcomPkg/Drivers/UFSDxe/UFSDxe.inf
-  INF Binaries/dodge/QcomPkg/Drivers/OplusStorageDxe/OplusStorageDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/CmdDbDxe/CmdDbDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/PwrUtilsDxe/PwrUtilsDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/RpmhDxe/RpmhDxe.inf
@@ -55,7 +54,7 @@
   INF Binaries/dodge/QcomPkg/Drivers/ULogDxe/ULogDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/MailboxDxe/MailboxDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/QcomScmiDxe/QcomScmiDxe.inf
-  #INF Binaries/dodge/QcomPkg/Drivers/CalibrationDxe/CalibrationDxe.inf
+  INF Binaries/dodge/QcomPkg/Drivers/CalibrationDxe/CalibrationDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/VcsDxe/VcsDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/ClockDxe/ClockDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/SPMIDxe/SPMIDxe.inf
@@ -76,7 +75,6 @@
 !endif
   #INF Binaries/dodge/QcomPkg/Drivers/GpiDxe/GpiDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/SPIDxe/SPIDxe.inf
-  INF Binaries/dodge/QcomPkg/Drivers/OplusFpgaDxe/OplusFpga.inf
   INF Binaries/dodge/QcomPkg/Drivers/SdccDxe/SdccDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/FeatureEnablerDxe/FeatureEnablerDxe.inf
 
@@ -92,10 +90,8 @@
   INF Binaries/dodge/QcomPkg/Drivers/IPCCDxe/IPCCDxe.inf
   #INF Binaries/dodge/QcomPkg/Drivers/GLinkDxe/GLinkDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/OcdtDxe/OplusProject.inf
-  INF Binaries/dodge/QcomPkg/Drivers/OplusS4ResetDxe/OplusS4ResetDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/PmicGlinkDxe/PmicGlinkDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/QcomChargerDxe/QcomChargerDxeLA.inf
-  INF Binaries/dodge/QcomPkg/Drivers/OplusVibrDxe/OplusVibrDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/UsbPwrCtrlDxe/UsbPwrCtrlDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/TsensDxe/TsensDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/DDRInfoDxe/DDRInfoDxe.inf
@@ -118,8 +114,6 @@
   INF Binaries/dodge/QcomPkg/Drivers/SPSSDxe/SPSSDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/FvUtilsDxe/FvUtilsEnhancedDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/RmVmDxe/RmVmDxe.inf
-  INF Binaries/dodge/QcomPkg/Drivers/OGaugeAuthDxe/OGaugeAuth.inf
   INF Binaries/dodge/QcomPkg/Drivers/ParserDxe/ParserEnhancedDxe.inf
   INF Binaries/dodge/QcomPkg/Drivers/SerialPortDxe/SerialPortDxe.inf
-  INF Binaries/dodge/QcomPkg/Drivers/OplusOrdumpDxe/OplusOrdump.inf
-  INF Binaries/dodge/QcomPkg/Drivers/OplusSecurityDxe/OplusSecurityDxe.inf
+


### PR DESCRIPTION
### Changes

<!-- Describe what you Changed. (Write below this Comment) -->
removed Oplus Dxes
### Reason

<!-- Explain why you made these Changes. (Write below this Comment) -->
To reduce UEFI size and prevent crashing on OplusS4ResetDxe
### Checklist

<!-- Replace the Space with an 'x' inside the '[ ]' to Check the Box. -->

* [x] Have the Changes been Tested?
* [x] Has the Source Code been Cleaned Up?
